### PR TITLE
I-8 - Replaced parse_args with parse_known_args as a backward compati…

### DIFF
--- a/k8s-handle.py
+++ b/k8s-handle.py
@@ -1,25 +1,24 @@
 #!/usr/bin/env python
 
-import sys
-import logging
-import config
 import argparse
-import settings
-import templating
+import logging
+import sys
 
-from k8s.resource import Provisioner
-from k8s.resource import ProvisioningError
-from k8s.deprecation_checker import ApiDeprecationChecker, DeprecationError
 from kubernetes.client import Configuration, VersionApi
 from kubernetes.config import load_kube_config
+
+import config
+import settings
+import templating
 from config import InvalidYamlException
-from config import get_client_config
 from config import check_required_vars
+from config import get_client_config
+from k8s.deprecation_checker import ApiDeprecationChecker, DeprecationError
+from k8s.resource import Provisioner
+from k8s.resource import ProvisioningError
 
 log = logging.getLogger(__name__)
-
 logging.basicConfig(level=settings.LOG_LEVEL, format=settings.LOG_FORMAT, datefmt=settings.LOG_DATE_FORMAT)
-
 
 parser = argparse.ArgumentParser(description='CLI utility generate k8s resources by templates and apply it to cluster')
 subparsers = parser.add_subparsers()
@@ -37,8 +36,6 @@ deploy_parser.add_argument('--strict', action='store_true', required=False,
                            help='Check existence of all env variables in config.yaml and stop deploy if var is not set')
 deploy_parser.add_argument('--use-kubeconfig', action='store_true', required=False, help='Try to use kube config')
 
-deploy_parser.set_defaults(command='deploy')
-
 destroy_parser = subparsers.add_parser('destroy', help='Sub command for destroy app')
 destroy_parser.add_argument('-s', '--section', required=True, type=str, help='Section to destroy from config file')
 destroy_parser.add_argument('-c', '--config', type=str, required=False, help='Config file, default: config.yaml')
@@ -51,24 +48,28 @@ destroy_parser.add_argument('--tries', type=int, required=False, default=360,
 destroy_parser.add_argument('--retry-delay', type=int, required=False, default=5, help='Sleep between tries in seconds')
 destroy_parser.add_argument('--use-kubeconfig', action='store_true', required=False, help='Try to use kube config')
 
-destroy_parser.set_defaults(command='destroy')
-
 
 def main():
-    args = parser.parse_args()
+    args = parser.parse_known_args()[0]
+
     if 'config' in args and args.config:
         settings.CONFIG_FILE = args.config
+
     if 'tries' in args:
         settings.CHECK_STATUS_TRIES = args.tries
         settings.CHECK_DAEMONSET_STATUS_TRIES = args.tries
+
     if 'retry_delay' in args:
         settings.CHECK_STATUS_TIMEOUT = args.retry_delay
         settings.CHECK_DAEMONSET_STATUS_TIMEOUT = args.retry_delay
+
     if 'strict' in args:
         settings.GET_ENVIRON_STRICT = args.strict
+
     if 'command' not in args:
         parser.print_help()
         sys.exit(1)
+
     try:
         context = config.load_context_section(args.section)
         log.info('Using default namespace {}'.format(context.get('k8s_namespace')))
@@ -78,16 +79,20 @@ def main():
 
         if args.dry_run:
             return
+
         if 'use_kubeconfig' in args and args.use_kubeconfig:
             load_kube_config()
         else:
             Configuration.set_default(get_client_config(context))
             check_required_vars(context, ['k8s_master_uri', 'k8s_token', 'k8s_ca_base64', 'k8s_namespace'])
+
         p = Provisioner(args.command, args.sync_mode)
         d = ApiDeprecationChecker(VersionApi().get_code().git_version[1:])
+
         for resource in resources:
             d.run(resource)
             p.run(resource)
+
     except templating.TemplateRenderingError as e:
         log.error('Template generation error: {}'.format(e))
         sys.exit(1)
@@ -102,6 +107,7 @@ def main():
         sys.exit(1)
     except ProvisioningError:
         sys.exit(1)
+
     print('''
                          _(_)_                          wWWWw   _
              @@@@       (_)@(_)   vVVVv     _     @@@@  (___) _(_)_


### PR DESCRIPTION
Fixes #8 

Суть:
Сейчас пользователи используют --sync-mode (true|false), --dry-run (true|false).
А должны --sync mode, --dry-run (without the explicit value).

Чтобы отказаться от лишних конструкций в коде и/или внешних переменных, на переходное время можно изменить парсинг на `parse_known_args`, тогда старые true уйдут в список "нераспарсенных аргументов".  Функциональность будет новой, старые деплои не повалятся, единственные кого заденет, будут те, кто раньше использовал --sync-mode false или --dry-run false, если такие были.

`set_defaults` убрал, т.к. всё равно жестко требуем указания команды.