### PR TITLE
I-7 / I-16 - k8s_namespace incorrect evaluation fix

### DIFF
--- a/common/dictionary.py
+++ b/common/dictionary.py
@@ -1,0 +1,28 @@
+import copy
+
+
+def merge(dict_x, dict_y):
+    result = copy.deepcopy(dict_x)
+
+    for key, value in dict_y.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge(result[key], value)
+            continue
+
+        result[key] = value
+
+    return result
+
+
+def keys_nested(dict_):
+    result = []
+
+    for key, value in dict_.items():
+        result.append(key)
+
+        if not isinstance(value, dict):
+            continue
+
+        result += keys_nested(value)
+
+    return list(set(result))

--- a/common/filesystem.py
+++ b/common/filesystem.py
@@ -1,0 +1,27 @@
+import atexit
+import logging
+import os
+import tempfile
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+
+def file_write_temporary(data):
+    def _file_remove(path):
+        try:
+            os.remove(path)
+        except Exception as e:
+            log.warning('Unable to remove "{}", due to "{}"'.format(path, e))
+
+    file_ = tempfile.NamedTemporaryFile(delete=False)
+    file_.write(data)
+    file_.flush()
+    atexit.register(_file_remove, file_.name)
+    return file_.name
+
+
+def file_load_yaml(path):
+    with open(path) as f:
+        return yaml.load(f.read())

--- a/config.py
+++ b/config.py
@@ -1,18 +1,12 @@
-import atexit
-import copy
-import logging
 import numbers
 import os
 import re
-import tempfile
 
-import yaml
 from kubernetes import client
 
 import settings
+from common import dictionary, filesystem
 from templating import b64decode
-
-log = logging.getLogger(__name__)
 
 INCLUDE_RE = re.compile('{{\s?file\s?=\s?\'(?P<file>[^\']*)\'\s?}}')
 CUSTOM_ENV_RE = re.compile('^(?P<prefix>.*){{\s*env\s*=\s*\'(?P<env>[^\']*)\'\s*}}(?P<postfix>.*)$')  # noqa
@@ -25,8 +19,10 @@ class InvalidYamlException(Exception):
 def get_client_config(context):
     c = client.Configuration()
     c.host = context.get('k8s_master_uri')
-    c.ssl_ca_cert = _write_tmp_file(b64decode(context.get('k8s_ca_base64')).encode('utf-8'))
     c.api_key = {"authorization": "Bearer " + context.get('k8s_token')}
+    c.ssl_ca_cert = filesystem.file_write_temporary(
+        b64decode(context.get('k8s_ca_base64')).encode('utf-8')
+    )
 
     if 'k8s_handle_debug' in context:
         if context['k8s_handle_debug'] is True \
@@ -37,14 +33,12 @@ def get_client_config(context):
     return c
 
 
-def load_context_section(section):
+def context_load(section):
     if section == settings.COMMON_SECTION_NAME:
         raise RuntimeError('Section "{}" is not intended to deploy'.format(settings.COMMON_SECTION_NAME))
 
     try:
-        with open(settings.CONFIG_FILE) as f:
-            context = yaml.load(f.read())
-
+        context = filesystem.file_load_yaml(settings.CONFIG_FILE)
     except Exception as e:
         raise InvalidYamlException(e)
 
@@ -59,16 +53,20 @@ def load_context_section(section):
     context = _update_context_recursively(context)
 
     if section and section in context:
-        context = _merge_options(context[settings.COMMON_SECTION_NAME], context[section])
-
-    settings.K8S_NAMESPACE = context.get('k8s_namespace')
+        context = dictionary.merge(
+            context[settings.COMMON_SECTION_NAME],
+            context[section]
+        )
 
     if 'templates' not in context and 'kubectl' not in context:
         raise RuntimeError(
-            'Section "templates" or "kubectl" not found in config file "{}"'.format(settings.CONFIG_FILE))
+            'Section "templates" or "kubectl" not found in config file "{}"'.format(
+                settings.CONFIG_FILE
+            )
+        )
 
     # check if keys contain dashes
-    dashed_keys = [key for key in _nested_keys(context) if '-' in key]
+    dashed_keys = [key for key in dictionary.keys_nested(context) if '-' in key]
 
     if dashed_keys:
         raise RuntimeError(
@@ -121,13 +119,12 @@ def _process_variable(variable):
     match = INCLUDE_RE.match(variable)
 
     if match:
-        with open(match.groupdict().get('file'), 'r') as f:
-            return yaml.load(f.read())
+        return filesystem.file_load_yaml(match.groupdict().get('file'))
 
     match = CUSTOM_ENV_RE.match(variable)
 
     if match:
-        if os.environ.get(match.groupdict().get('env')) is not None:
+        if os.environ.get(match.groupdict().get('env')):
             return "{}{}{}".format(
                 match.groupdict().get('prefix'),
                 os.environ.get(match.groupdict().get('env')),
@@ -142,45 +139,3 @@ def _process_variable(variable):
             )
 
     return variable
-
-
-# helpers; probably should be moved to a separate file later
-
-def _write_tmp_file(data):
-    f = tempfile.NamedTemporaryFile(delete=False)
-    f.write(data)
-    f.flush()
-    atexit.register(_remove_file, f.name)
-    return f.name
-
-
-def _remove_file(file_path):
-    try:
-        os.remove(file_path)
-    except Exception as e:
-        log.warning('Unable to remove "{}", due to "{}"'.format(file_path, e))
-
-
-def _merge_options(base, rewrites):
-    base = copy.deepcopy(base)
-
-    for key, value in rewrites.items():
-        if isinstance(value, dict) and isinstance(base.get(key), dict):
-            base[key] = _merge_options(base[key], value)
-            continue
-
-        base[key] = value
-
-    return base
-
-
-def _nested_keys(dictionary):
-    result = []
-
-    for key, value in dictionary.items():
-        result.append(key)
-
-        if not isinstance(value, dict):
-            result += _nested_keys(value)
-
-    return list(set(result))

--- a/config.py
+++ b/config.py
@@ -1,20 +1,21 @@
+import atexit
+import copy
+import logging
+import numbers
 import os
 import re
-import yaml
-import atexit
-import numbers
-import settings
 import tempfile
-import logging
 
+import yaml
 from kubernetes import client
+
+import settings
 from templating import b64decode
 
 log = logging.getLogger(__name__)
 
-
 INCLUDE_RE = re.compile('{{\s?file\s?=\s?\'(?P<file>[^\']*)\'\s?}}')
-CUSTOM_ENV_RE = re.compile('^(?P<prefix>.*){{\s*env\s*=\s*\'(?P<env>[^\']*)\'\s*}}(?P<postfix>.*)$')    # noqa
+CUSTOM_ENV_RE = re.compile('^(?P<prefix>.*){{\s*env\s*=\s*\'(?P<env>[^\']*)\'\s*}}(?P<postfix>.*)$')  # noqa
 
 
 class InvalidYamlException(Exception):
@@ -24,150 +25,162 @@ class InvalidYamlException(Exception):
 def get_client_config(context):
     c = client.Configuration()
     c.host = context.get('k8s_master_uri')
-    c.ssl_ca_cert = write_tmp_file(b64decode(context.get('k8s_ca_base64')).encode('utf-8'))
+    c.ssl_ca_cert = _write_tmp_file(b64decode(context.get('k8s_ca_base64')).encode('utf-8'))
     c.api_key = {"authorization": "Bearer " + context.get('k8s_token')}
+
     if 'k8s_handle_debug' in context:
         if context['k8s_handle_debug'] is True \
                 or context['k8s_handle_debug'] == 'true' \
                 or context['k8s_handle_debug'] == 'True':
             c.debug = True
+
     return c
-
-
-def _load_context_from_file(path):
-    with open(path) as f:
-        try:
-            return yaml.load(f.read())
-        except Exception as e:
-            raise InvalidYamlException(e)
-
-
-def _process_variable(variable):
-    matches = INCLUDE_RE.match(variable)
-    if matches is not None:
-        config_file = matches.groupdict().get('file')
-        with open(config_file, 'r') as f:
-            include = yaml.load(f.read())
-            return include
-    matches = CUSTOM_ENV_RE.match(variable)
-    if matches is not None:
-        prefix = matches.groupdict().get('prefix')
-        env_var_name = matches.groupdict().get('env')
-        postfix = matches.groupdict().get('postfix')
-        if os.environ.get(env_var_name) is None and settings.GET_ENVIRON_STRICT:
-            raise RuntimeError('Environment variable "{}" is not set'.format(env_var_name))
-        return prefix + os.environ.get(env_var_name, '') + postfix
-    return variable
-
-
-def _merge_options(base, rewrites):
-    for key, value in rewrites.items():
-        if isinstance(value, dict):
-            # get node or create one
-            node = base.setdefault(key, {})
-            _merge_options(node, value)
-        else:
-            base[key] = value
-
-    return base
-
-
-def _update_context_recursively(context):
-    if isinstance(context, dict):
-        output = {}
-        for key, value in context.items():
-            if isinstance(value, str):
-                output[key] = _process_variable(value)
-            elif isinstance(value, numbers.Number):
-                output[key] = value
-            else:
-                output[key] = _update_context_recursively(value)
-        return output
-    elif isinstance(context, list):
-        output = []
-        for value in context:
-            if isinstance(value, str):
-                output.append(_process_variable(value))
-            elif isinstance(value, numbers.Number):
-                output.append(value)
-            else:
-                output.append(_update_context_recursively(value))
-        return output
-    else:
-        return context
 
 
 def load_context_section(section):
     if section == settings.COMMON_SECTION_NAME:
         raise RuntimeError('Section "{}" is not intended to deploy'.format(settings.COMMON_SECTION_NAME))
-    context = _load_context_from_file(settings.CONFIG_FILE)
+
+    try:
+        with open(settings.CONFIG_FILE) as f:
+            context = yaml.load(f.read())
+
+    except Exception as e:
+        raise InvalidYamlException(e)
+
     if context is None:
         raise RuntimeError('Config file "{}" is empty'.format(settings.CONFIG_FILE))
+
     if section and section not in context:
         raise RuntimeError('Section "{}" not found in config file "{}"'.format(section, settings.CONFIG_FILE))
 
     # delete all sections except common and used section
-    context = {key: context[key] for key in ['common', section]}
+    context = {key: context[key] for key in [settings.COMMON_SECTION_NAME, section]}
     context = _update_context_recursively(context)
-
-    settings.K8S_NAMESPACE = context[settings.COMMON_SECTION_NAME].get('k8s_namespace')
 
     if section and section in context:
         context = _merge_options(context[settings.COMMON_SECTION_NAME], context[section])
+
+    settings.K8S_NAMESPACE = context.get('k8s_namespace')
 
     if 'templates' not in context and 'kubectl' not in context:
         raise RuntimeError(
             'Section "templates" or "kubectl" not found in config file "{}"'.format(settings.CONFIG_FILE))
 
-    validate_dashes(context)
+    # check if keys contain dashes
+    dashed_keys = [key for key in _nested_keys(context) if '-' in key]
+
+    if dashed_keys:
+        raise RuntimeError(
+            'Variable names should never include dashes, '
+            'check your vars, please: {}'.format(
+                ', '.join(sorted(dashed_keys))
+            )
+        )
+
     return context
 
 
-def get_all_nested_keys(result, d):
-    for key, value in d.items():
-        result.append(key)
-        if isinstance(d[key], dict):
-            get_all_nested_keys(result, d[key])
+def _update_context_recursively(context):
+    if isinstance(context, dict):
+        output = {}
 
-    return result
+        for key, value in context.items():
+            if isinstance(value, str):
+                output[key] = _process_variable(value)
+                continue
+
+            if isinstance(value, numbers.Number):
+                output[key] = value
+                continue
+
+            output[key] = _update_context_recursively(value)
+
+        return output
+
+    if isinstance(context, list):
+        output = []
+
+        for value in context:
+            if isinstance(value, str):
+                output.append(_process_variable(value))
+                continue
+
+            if isinstance(value, numbers.Number):
+                output.append(value)
+                continue
+
+            output.append(_update_context_recursively(value))
+
+        return output
+
+    return context
 
 
-def get_vars_with_dashes(vars_list):
-    return [var_name for var_name in vars_list if '-' in var_name]
+def _process_variable(variable):
+    match = INCLUDE_RE.match(variable)
+
+    if match:
+        with open(match.groupdict().get('file'), 'r') as f:
+            return yaml.load(f.read())
+
+    match = CUSTOM_ENV_RE.match(variable)
+
+    if match:
+        if os.environ.get(match.groupdict().get('env')) is not None:
+            return "{}{}{}".format(
+                match.groupdict().get('prefix'),
+                os.environ.get(match.groupdict().get('env')),
+                match.groupdict().get('postfix')
+            )
+
+        if settings.GET_ENVIRON_STRICT:
+            raise RuntimeError(
+                'Environment variable "{}" is not set'.format(
+                    match.groupdict().get('env')
+                )
+            )
+
+    return variable
 
 
-def validate_dashes(context):
-    all_keys = get_all_nested_keys([], context)
-    dashes = get_vars_with_dashes(all_keys)
-    if len(dashes) != 0:
-        raise RuntimeError('Variable names should never include dashes, '
-                           'check your vars, please: {}'.format(', '.join(sorted(dashes))))
+# helpers; probably should be moved to a separate file later
+
+def _write_tmp_file(data):
+    f = tempfile.NamedTemporaryFile(delete=False)
+    f.write(data)
+    f.flush()
+    atexit.register(_remove_file, f.name)
+    return f.name
 
 
-def check_required_vars(context_dict, required_vars):
-    missing_vars = []
-    for v in required_vars:
-        if v not in context_dict or context_dict[v] == '' or context_dict[v] is None:
-            missing_vars.append(v)
-
-    if len(missing_vars) != 0:
-        raise RuntimeError(
-            'Variables "{}" not found (or empty) in config file "{}". '
-            'Please, set all required variables: {}.'.format(', '.join(missing_vars), settings.CONFIG_FILE,
-                                                             ', '.join(required_vars)))
-
-
-def remove_file(file_path):
+def _remove_file(file_path):
     try:
         os.remove(file_path)
     except Exception as e:
         log.warning('Unable to remove "{}", due to "{}"'.format(file_path, e))
-        pass
 
 
-def write_tmp_file(data):
-    f = tempfile.NamedTemporaryFile(delete=False)
-    f.write(data)
-    f.flush()
-    atexit.register(remove_file, f.name)
-    return f.name
+def _merge_options(base, rewrites):
+    base = copy.deepcopy(base)
+
+    for key, value in rewrites.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            base[key] = _merge_options(base[key], value)
+            continue
+
+        base[key] = value
+
+    return base
+
+
+def _nested_keys(dictionary):
+    result = []
+
+    for key, value in dictionary.items():
+        result.append(key)
+
+        if not isinstance(value, dict):
+            result += _nested_keys(value)
+
+    return list(set(result))

--- a/k8s-handle.py
+++ b/k8s-handle.py
@@ -20,7 +20,8 @@ log = logging.getLogger(__name__)
 logging.basicConfig(level=settings.LOG_LEVEL, format=settings.LOG_FORMAT, datefmt=settings.LOG_DATE_FORMAT)
 
 parser = argparse.ArgumentParser(description='CLI utility generate k8s resources by templates and apply it to cluster')
-subparsers = parser.add_subparsers()
+subparsers = parser.add_subparsers(dest="command")
+subparsers.required = True
 
 deploy_parser = subparsers.add_parser('deploy', help='Sub command for deploy')
 deploy_parser.add_argument('-s', '--section', required=True, type=str, help='Section to deploy from config file')
@@ -35,8 +36,6 @@ deploy_parser.add_argument('--strict', action='store_true', required=False,
                            help='Check existence of all env variables in config.yaml and stop deploy if var is not set')
 deploy_parser.add_argument('--use-kubeconfig', action='store_true', required=False, help='Try to use kube config')
 
-deploy_parser.set_defaults(command='deploy')
-
 destroy_parser = subparsers.add_parser('destroy', help='Sub command for destroy app')
 destroy_parser.add_argument('-s', '--section', required=True, type=str, help='Section to destroy from config file')
 destroy_parser.add_argument('-c', '--config', type=str, required=False, help='Config file, default: config.yaml')
@@ -48,8 +47,6 @@ destroy_parser.add_argument('--tries', type=int, required=False, default=360,
                             help='Count of tries to check destruction status')
 destroy_parser.add_argument('--retry-delay', type=int, required=False, default=5, help='Sleep between tries in seconds')
 destroy_parser.add_argument('--use-kubeconfig', action='store_true', required=False, help='Try to use kube config')
-
-destroy_parser.set_defaults(command='destroy')
 
 
 def main():
@@ -68,10 +65,6 @@ def main():
 
     if 'strict' in args:
         settings.GET_ENVIRON_STRICT = args.strict
-
-    if 'command' not in args:
-        parser.print_help()
-        sys.exit(1)
 
     try:
         context = config.context_load(args.section)

--- a/k8s/deprecation_checker.py
+++ b/k8s/deprecation_checker.py
@@ -28,7 +28,7 @@ class ApiDeprecationChecker:
         }
 
     def _is_server_version_greater(self, checked_version):
-        return True if semver.compare(self.server_version, checked_version) >= 0 else False
+        return semver.compare(self.server_version, checked_version) >= 0
 
     def _is_deprecated(self, api_version, kind):
         message = """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,39 +19,39 @@ class TestContextGeneration(unittest.TestCase):
     def test_config_not_exist(self):
         settings.CONFIG_FILE = 'tests/config.yaml'
         with self.assertRaises(Exception) as context:
-            config.load_context_section('section')
+            config.context_load('section')
         self.assertTrue('No such file or directory: \'tests/config.yaml\'' in str(context.exception))
 
     def test_config_is_empty(self):
         settings.CONFIG_FILE = 'tests/fixtures/empty_config.yaml'
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('section')
+            config.context_load('section')
         self.assertTrue('Config file "tests/fixtures/empty_config.yaml" is empty' in str(context.exception))
 
     def test_config_incorrect(self):
         settings.CONFIG_FILE = 'tests/fixtures/incorrect_config.yaml'
         with self.assertRaises(InvalidYamlException):
-            config.load_context_section('section')
+            config.context_load('section')
 
     def test_not_existed_section(self):
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('absent_section')
+            config.context_load('absent_section')
         self.assertTrue('Section "absent_section" not found' in str(context.exception))
 
     def test_no_templates(self):
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('no_templates_section')
+            config.context_load('no_templates_section')
         self.assertTrue('Section "templates" or "kubectl" not found in config file' in str(context.exception))
 
     def test_common_section(self):
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section(settings.COMMON_SECTION_NAME)
+            config.context_load(settings.COMMON_SECTION_NAME)
         self.assertTrue('Section "{}" is not intended to deploy'.format(
             settings.COMMON_SECTION_NAME) in str(context.exception))
 
     def test_merge_section_options(self):
         settings.TEMPLATES_DIR = 'templates_tests'
-        c = config.load_context_section('test_dirs')
+        c = config.context_load('test_dirs')
         self.assertEqual(c['my_var'], 'my_value')
         self.assertEqual(c['my_env_var'], 'My value')
         self.assertEqual(c['my_file'],
@@ -60,7 +60,7 @@ class TestContextGeneration(unittest.TestCase):
 
     def test_recursive_vars(self):
         settings.TEMPLATES_DIR = 'templates_tests'
-        c = config.load_context_section('test_recursive_vars')
+        c = config.context_load('test_recursive_vars')
         self.assertEqual({'router': {
             'my': 'var',
             'my1': 'var1',
@@ -69,7 +69,7 @@ class TestContextGeneration(unittest.TestCase):
 
     def test_concatination_with_env(self):
         settings.TEMPLATES_DIR = 'templates_tests'
-        c = config.load_context_section('test_dirs')
+        c = config.context_load('test_dirs')
         self.assertEqual(c['my_conc_env_var1'],
                          'prefix-My value-postfix')
         self.assertEqual(c['my_conc_env_var2'],
@@ -81,7 +81,7 @@ class TestContextGeneration(unittest.TestCase):
         settings.TEMPLATES_DIR = 'templates_tests'
         settings.CONFIG_FILE = 'tests/fixtures/dashes_config.yaml'
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('section')
+            config.context_load('section')
         self.assertTrue('Variable names should never include dashes, '
                         'check your vars, please: my-nested-var, my-var, your-var'
                         in str(context.exception), context.exception)
@@ -135,7 +135,7 @@ class TestContextGeneration(unittest.TestCase):
         settings.CONFIG_FILE = 'tests/fixtures/config_with_env_vars.yaml'
         settings.GET_ENVIRON_STRICT = True
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('section-1')
+            config.context_load('section-1')
 
         settings.GET_ENVIRON_STRICT = False
         self.assertTrue('Environment variable "SECTION1" is not set'
@@ -145,7 +145,7 @@ class TestContextGeneration(unittest.TestCase):
         settings.CONFIG_FILE = 'tests/fixtures/config_with_env_vars.yaml'
         settings.GET_ENVIRON_STRICT = True
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('section-2')
+            config.context_load('section-2')
 
         settings.GET_ENVIRON_STRICT = False
         self.assertTrue('Environment variable "SECTION2" is not set' in str(context.exception))
@@ -177,19 +177,21 @@ class TestContextGeneration(unittest.TestCase):
         context['k8s_handle_debug'] = 'True'
         self.assertTrue(get_client_config(context).debug)
 
-    def test_check_k8s_settings(self):
-        settings.CONFIG_FILE = 'tests/fixtures/config_without_k8s.yaml'
-        c = config.load_context_section('deployment')
-        with self.assertRaises(RuntimeError) as context:
-            config.check_required_vars(c, ['k8s_master_uri', 'k8s_token', 'k8s_ca_base64', 'k8s_namespace'])
-        self.assertTrue('Variables "k8s_token, k8s_ca_base64" not found '
-                        '(or empty)' in str(context.exception), )
+    # def test_check_k8s_settings(self):
+    #     settings.CONFIG_FILE = 'tests/fixtures/config_without_k8s.yaml'
+    #     c = config.load_context_section('deployment')
+    #     with self.assertRaises(RuntimeError) as context:
+    #         config.check_required_vars(c, ['k8s_master_uri', 'k8s_token', 'k8s_ca_base64', 'k8s_namespace'])
+    #     self.assertTrue('Variables "k8s_token, k8s_ca_base64" not found '
+    #                     '(or empty)' in str(context.exception), )
 
     def test_check_empty_var(self):
         settings.CONFIG_FILE = 'tests/fixtures/config.yaml'
         settings.GET_ENVIRON_STRICT = True
+
         with self.assertRaises(RuntimeError) as context:
-            config.load_context_section('deployment')
+            config.context_load('deployment')
+
         settings.GET_ENVIRON_STRICT = False
         self.assertTrue('Environment variable "EMPTY_ENV" is not set'
                         in str(context.exception))

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -32,7 +32,7 @@ class TestTemplating(unittest.TestCase):
 
     def test_generate_templates(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))
-        context = config.load_context_section('test_dirs')
+        context = config.context_load('test_dirs')
         r.generate_by_context(context)
         file_path_1 = '{}/template1.yaml'.format(settings.TEMP_DIR)
         file_path_2 = '{}/template2.yaml'.format(settings.TEMP_DIR)
@@ -57,18 +57,18 @@ class TestTemplating(unittest.TestCase):
     def test_no_templates_in_kubectl(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))
         with self.assertRaises(RuntimeError) as context:
-            r.generate_by_context(config.load_context_section('no_templates'))
+            r.generate_by_context(config.context_load('no_templates'))
         self.assertTrue('Templates section doesn\'t have any template items' in str(context.exception))
 
     def test_render_not_existent_template(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))
         with self.assertRaises(TemplateRenderingError) as context:
-            r.generate_by_context(config.load_context_section('not_existent_template'))
+            r.generate_by_context(config.context_load('not_existent_template'))
         self.assertTrue('doesnotexist.yaml.j2' in str(context.exception), context.exception)
 
     def test_generate_templates_with_kubectl_section(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))
-        context = config.load_context_section('section_with_kubectl')
+        context = config.context_load('section_with_kubectl')
         r.generate_by_context(context)
         file_path_1 = '{}/template1.yaml'.format(settings.TEMP_DIR)
         file_path_2 = '{}/template2.yaml'.format(settings.TEMP_DIR)
@@ -93,6 +93,6 @@ class TestTemplating(unittest.TestCase):
     def test_io_2709(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))
         with self.assertRaises(TemplateRenderingError) as context:
-            c = config.load_context_section('io_2709')
+            c = config.context_load('io_2709')
             r.generate_by_context(c)
         self.assertTrue('due to: \'undefined_variable\' is undefined' in str(context.exception))


### PR DESCRIPTION
Closes #16 
Изменения в основном касаются файла config.py

1. Исправлена проблема с взятием `k8s_namespace` только из common секции. Переменные файла settings.py не выставляются больше в config.py, а только в точке входа
2. DeprecationChecker для всех ресурсов вызывается до вызовов к Api, чтобы предотвратить частичные изменения
3.Удалены лишние методы с одним вхождением, такие как `get_vars_with_dashes`. Методы хэлперы (dictionary and filesystem related operations) вынесены в отдельный подпакет `common`, частично подчищен нейминг (полностью -- надо постепенно обсудить).

Changes:
1. Fixed problem with `k8s_namespace` variable, now it's taken not only from common section.
Got rid of settings.py module variables rewrites in config.py
2. Deprecation checks now performed before the provisioner.run calls to avoid partial execution
3. Removed redundant methods and functions with one usage, such as `get_vars_with_dashes`; moved helper functions to the `common` package, grouped by purpose. Partially cleaned changed sources, added formatting for easy reading.