### PR TITLE
I-30 -- Ensure correct default namespace evaluation priority, add ind…

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ from kubernetes import client
 
 import settings
 from dictionary import merge
-from filesystem import write_file_tmp, load_yaml
+from filesystem import load_yaml, write_file_tmp
 from templating import b64decode
 
 log = logging.getLogger(__name__)

--- a/k8s/resource.py
+++ b/k8s/resource.py
@@ -184,6 +184,7 @@ class Provisioner:
     def _deploy(self, file_path):
         template_body = get_template_context(file_path)
         kube_client = Adapter(template_body)
+        log.info('Using namespace "{}"'.format(kube_client.namespace))
 
         if kube_client.api is None:
             raise RuntimeError('Unknown apiVersion "{}" in template "{}"'.format(template_body['apiVersion'],
@@ -266,6 +267,7 @@ class Provisioner:
     def _destroy(self, file_path):
         template_body = get_template_context(file_path)
         kube_client = Adapter(template_body)
+        log.info('Using namespace "{}"'.format(kube_client.namespace))
         log.info('Trying to delete {} "{}"'.format(template_body['kind'], kube_client.name))
         if kube_client.api is None:
             raise RuntimeError('Unknown apiVersion "{}" in template "{}"'.format(template_body['apiVersion'],


### PR DESCRIPTION
…ication of namespace that adapter finally uses.

Closes #30 

Expected behavior and k8s namespace evaluation priority (higher first):
1. From spec template.
2. From config.yaml.
3. From ~/.kube/config if use-kubeconfig flag is set.
4. From env.

Current state:
1. From spec template
2. From config.yaml

Moreover, despite namespace can be taken from 1, only the value from 2 is shown in "Using namespace {}" message, that's not correct.

So I propose to fill `settings.K8S_NAMESPACE` (which  should probably be renamed K8S_NAMESPACE_DEFAULT) in reversed order: at first, value is taken from env, then (if use-kubeconfig) the attempt to look into ~/.kube/config is performed, then it's overriden by config.yaml dict value, if any.

Further, at the adapter level, it can be used if there's not any corresponding namespace field in a template spec, just as before. Additional log message about exactly used namespace is added.
