### PR TITLE
I-46 - Accept connection parameters from CLI and env variables.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -9,11 +9,9 @@ CONFIG_FILE = os.environ.get('CONFIG_FILE', 'config.yaml')
 COMMON_SECTION_NAME = 'common'
 TEMPLATES_DIR = os.environ.get('TEMPLATES_DIR', 'templates')
 
-K8S_CA = os.environ.get('K8S_CA')
-K8S_HOST = os.environ.get('K8S_HOST')
-K8S_TOKEN = os.environ.get('K8S_TOKEN')
-K8S_NAMESPACE = os.environ.get('K8S_NAMESPACE')
 K8S_CONFIG_DIR = os.environ.get('K8S_CONFIG_DIR', '{}/.kube/'.format(os.path.expanduser('~')))
+
+K8S_NAMESPACE = None
 
 TEMP_DIR = os.environ.get('TEMP_DIR', '/tmp/k8s-handle')
 


### PR DESCRIPTION
Closes #46 

Имплементация поддержки CLI/Env параметров соединения с K8S.

Часть глобальных переменных из settings перекочевала в объект эвалуатор, ввиду того, что нет нужды держать их глобальными. Логика их заполнения также усложнилась и стала связана с контекстом  из main, поэтому перенёс туда.

Implementation of CLI/Env settings of the connection parameters support.
Notes:
Some global connection variables from settings.py moved to k8s-handle.py/config.py, due to the more complex logic of their evaluation and because of single usage. `get_client_config` and `check_required_vars` functions were abolished as well due to single usage.