### PR TITLE
soft deprecation check, if k8s client supporting api version

### DIFF
--- a/k8s/deprecation_checker.py
+++ b/k8s/deprecation_checker.py
@@ -17,7 +17,7 @@ class ApiDeprecationChecker:
         self.deprecated_versions = {
             "extensions/v1beta1": {
                 "since": "1.8.0",
-                "until": "1.11.0",
+                "until": "",
                 "resources": [
                     "Deployment",
                     "DaemonSet",
@@ -46,20 +46,21 @@ class ApiDeprecationChecker:
         if kind not in self.deprecated_versions[api_version].get("resources"):
             return False
 
-        if self._is_server_version_greater(self.deprecated_versions[api_version]["until"]):
-            log.warning(message.format(
-                api_version=api_version,
-                kind=kind,
-                status="unsupported",
-                k8s_version=self.deprecated_versions[api_version]["until"],
-            ))
-            raise DeprecationError(
-                "Version {} for resourse type '{}' is unsupported since kubernetes {}".format(
-                    api_version,
-                    kind,
-                    self.deprecated_versions[api_version]["until"]
+        if self.deprecated_versions[api_version]["until"]:
+            if self._is_server_version_greater(self.deprecated_versions[api_version]["until"]):
+                log.warning(message.format(
+                    api_version=api_version,
+                    kind=kind,
+                    status="unsupported",
+                    k8s_version=self.deprecated_versions[api_version]["until"],
+                ))
+                raise DeprecationError(
+                    "Version {} for resourse type '{}' is unsupported since kubernetes {}".format(
+                        api_version,
+                        kind,
+                        self.deprecated_versions[api_version]["until"]
+                    )
                 )
-            )
 
         if self._is_server_version_greater(self.deprecated_versions[api_version]["since"]):
             log.warning(message.format(

--- a/k8s/test_deprecation_checker.py
+++ b/k8s/test_deprecation_checker.py
@@ -97,3 +97,16 @@ class TestApiDeprecationChecker(unittest.TestCase):
         }
         with self.assertRaises(DeprecationError):
             checker._is_deprecated("test/v1", "Deployment")
+
+    def test_version_no_until(self):
+        checker = ApiDeprecationChecker("1.10.6")
+        checker.deprecated_versions = {
+            "test/v1": {
+                "since": "1.8.0",
+                "until": "",
+                "resources": [
+                    "Deployment",
+                ],
+            }
+        }
+        self.assertTrue(checker._is_deprecated("test/v1", "Deployment"))


### PR DESCRIPTION
если kubernetes client поддерживает версию - позволяем ею пользоваться,
версию в until будем проставлять только в случае если с помощью нее невозможно подеплоить в кластер.

Принудительное нанесение добра людям не нравится.