### PR TITLE
Make CA certificate optional in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Configure checkout for https://github.com/2gis/k8s-handle-example.git and specif
 Also you need to setup next env vars:
 * K8S_NAMESPACE
 * K8S_MASTER_URI
-* K8S_CA_BASE64
+* K8S_CA_BASE64 (optional)
 * K8S_TOKEN
 
 use image 2gis/k8s-handle:<version or latest>

--- a/k8s_handle/config.py
+++ b/k8s_handle/config.py
@@ -48,7 +48,6 @@ class PriorityEvaluator:
     def k8s_client_configuration(self):
         for parameter, value in {
             KEY_K8S_MASTER_URI: self._k8s_master_uri(),
-            KEY_K8S_CA_BASE64: self._k8s_ca_base64(),
             KEY_K8S_TOKEN: self._k8s_token()
         }.items():
             if value:
@@ -59,7 +58,10 @@ class PriorityEvaluator:
 
         configuration = client.Configuration()
         configuration.host = self._k8s_master_uri()
-        configuration.ssl_ca_cert = write_file_tmp(b64decode(self._k8s_ca_base64()).encode('utf-8'))
+
+        if self._k8s_ca_base64():
+            configuration.ssl_ca_cert = write_file_tmp(b64decode(self._k8s_ca_base64()).encode('utf-8'))
+
         configuration.api_key = {"authorization": "Bearer " + self._k8s_token()}
         configuration.debug = self._k8s_handle_debug()
         return configuration

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,12 +244,6 @@ class TestPriorityEvaluation(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             evaluator.k8s_client_configuration()
 
-    def test_k8s_client_configuration_missing_k8s_ca(self):
-        evaluator = PriorityEvaluator({KEY_K8S_MASTER_URI: VALUE_CLI, KEY_K8S_TOKEN: VALUE_CLI}, {}, {})
-
-        with self.assertRaises(RuntimeError):
-            evaluator.k8s_client_configuration()
-
     def test_k8s_client_configuration_missing_token(self):
         evaluator = PriorityEvaluator({
             KEY_K8S_MASTER_URI: VALUE_CLI,


### PR DESCRIPTION
CA certificate is not required by Kubernetes client actually: https://github.com/kubernetes-client/python/blob/v10.0.1/kubernetes/client/rest.py#L72-L77.