### PR TITLE
Update list of deprecated api versions by Kubernetes 1.16

### DIFF
--- a/k8s_handle/k8s/deprecation_checker.py
+++ b/k8s_handle/k8s/deprecation_checker.py
@@ -35,7 +35,7 @@ class ApiDeprecationChecker:
                 },
                 "Ingress": {
                     "since": "1.14.0",
-                    "until": "1.19.0",
+                    "until": "1.20.0",
                 },
             },
             "apps/v1beta1": {
@@ -84,6 +84,22 @@ class ApiDeprecationChecker:
                 "PriorityClass": {
                     "since": "1.14.0",
                     "until": "1.17.0",
+                },
+            },
+            "apiextensions.k8s.io/v1beta1": {
+                "CustomResourceDefinition": {
+                    "since": "1.16.0",
+                    "until": "1.19.0",
+                },
+            },
+            "admissionregistration.k8s.io/v1beta1": {
+                "MutatingWebhookConfiguration": {
+                    "since": "1.16.0",
+                    "until": "1.19.0",
+                },
+                "ValidatingWebhookConfiguration": {
+                    "since": "1.16.0",
+                    "until": "1.19.0",
                 },
             },
         }


### PR DESCRIPTION
Обновляем ещё раз...

Changelog: https://github.com/kubernetes/kubernetes/blob/release-1.16/CHANGELOG-1.16.md#deprecations-and-removals