### PR TITLE
Fix --skip-tags evaluation logic

### DIFF
--- a/k8s_handle/templating.py
+++ b/k8s_handle/templating.py
@@ -195,7 +195,10 @@ class Renderer:
 
     @staticmethod
     def _evaluate_tags(tags, only_tags, skip_tags):
-        if only_tags is None and skip_tags is None:
-            return True
+        if only_tags and tags.isdisjoint(only_tags):
+            return False
 
-        return tags.isdisjoint(skip_tags or []) and not tags.isdisjoint(only_tags or tags)
+        if skip_tags and not tags.isdisjoint(skip_tags):
+            return False
+
+        return True

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -111,6 +111,9 @@ class TestTemplating(unittest.TestCase):
         self.assertFalse(r._evaluate_tags(tags, only_tags=['tag1'], skip_tags=['tag1']))
         self.assertFalse(r._evaluate_tags(tags, only_tags=None, skip_tags=['tag1']))
         self.assertTrue(r._evaluate_tags(tags, only_tags=None, skip_tags=['tag4']))
+        tags = set()
+        self.assertFalse(r._evaluate_tags(tags, only_tags=['tag4'], skip_tags=None))
+        self.assertTrue(r._evaluate_tags(tags, only_tags=None, skip_tags=['tag4']))
 
     def test_get_template_tags(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))


### PR DESCRIPTION
Closes #119.

Previous version of `Renderer._evaluate_tags()` didn't work well because of:

```
>>> tags=set()
>>> only_tags=tags
>>> tags.isdisjoint(only_tags)
True
```