### PR TITLE
add list_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Apps
+*.DS_Store
+.vscode/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,3 @@ ENV/
 
 # mypy
 .mypy_cache/
-
-# Apps
-*.DS_Store
-.vscode/
-.idea/

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ templates
 my_file.txt
 ...
 ``` 
-> Note, `include_file` also support unix glob. You can import all files from directory conf.d/*.conf for example.
+* `{{ list_files('dir/or/glob*') }}` - returns list of files in specified directory. Useful for including all files in folder to configmap. You specify directory path relative to parent of templates folder.
+> Note, both fuctions support unix glob. You can import all files from directory `conf.d/*.conf` for example.
 
 You can put *.j2 templates in 'templates' directory and specify it in config.yaml
 ```yaml

--- a/k8s_handle/templating.py
+++ b/k8s_handle/templating.py
@@ -68,10 +68,18 @@ def get_env(templates_dir):
     def include_file(path):
         path = os.path.join(templates_dir, '../', path)
         output = []
-        for file_path in glob.glob(path):
+        for file_path in sorted(glob.glob(path)):
             with open(file_path, 'r') as f:
                 output.append(f.read())
         return '\n'.join(output)
+
+    def list_files(path):
+        path = os.path.join(templates_dir, '../', path)
+        if os.path.isdir(path):
+            files = [os.path.join(path, f) for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+        else:
+            files = glob.glob(path)
+        return sorted(files)
 
     env = Environment(
         undefined=StrictUndefined,
@@ -82,6 +90,7 @@ def get_env(templates_dir):
     env.filters['hash_sha256'] = hash_sha256
     env.filters['to_yaml'] = to_yaml
     env.globals['include_file'] = include_file
+    env.globals['list_files'] = list_files
 
     log.debug('Available templates in path {}: {}'.format(templates_dir, env.list_templates()))
     return env

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -33,6 +33,7 @@ test_dirs:
     - template: template3.yaml.j2
     - template: template_include_file.yaml.j2
     - template: innerdir/template1.yaml.j2
+    - template: template_list_files.yaml.j2
 
 no_templates:
   templates:

--- a/tests/templates_tests/template_list_files.yaml.j2
+++ b/tests/templates_tests/template_list_files.yaml.j2
@@ -1,0 +1,7 @@
+test: |
+  {% for f in list_files('templates_tests/innerdir') -%}
+  {{ f.split('/')[-1] }}:
+  {% endfor -%}
+  {% for f in list_files('templates_tests/my_file*.txt') -%}
+  {{ f.split('/')[-1] }}:
+  {% endfor -%}

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -41,6 +41,7 @@ class TestTemplating(unittest.TestCase):
         file_path_3 = '{}/template3.yaml'.format(settings.TEMP_DIR)
         file_path_4 = '{}/innerdir/template1.yaml'.format(settings.TEMP_DIR)
         file_path_5 = '{}/template_include_file.yaml'.format(settings.TEMP_DIR)
+        file_path_6 = '{}/template_list_files.yaml'.format(settings.TEMP_DIR)
         self.assertTrue(os.path.exists(file_path_1))
         self.assertTrue(os.path.exists(file_path_2))
         self.assertTrue(os.path.exists(file_path_3))
@@ -58,7 +59,10 @@ class TestTemplating(unittest.TestCase):
         self.assertEqual(content, "{'ha_ha': 'included_var'}")
         with open(file_path_5, 'r') as f:
             content = f.read()
-        self.assertEqual(content, "test: |\n  {{ hello world1 }}\n\n  {{ hello world }}\n  new\n  line")
+        self.assertEqual(content, "test: |\n  {{ hello world }}\n  new\n  line\n  {{ hello world1 }}\n")
+        with open(file_path_6, 'r') as f:
+            content = f.read()
+        self.assertEqual(content, "test: |\n  template1.yaml.j2:\n  my_file.txt:\n  my_file1.txt:\n  ")
 
     def test_no_templates_in_kubectl(self):
         r = templating.Renderer(os.path.join(os.path.dirname(__file__), 'templates_tests'))


### PR DESCRIPTION
Currently if you want to create configmap from all files in directory - you write such template:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: prometheus-rules
data:
  backup.yaml: |
    {{ include_file('prometheus/rules/backup.yaml') | indent }}
  blackbox.yaml: |
    {{ include_file('prometheus/rules/blackbox.yaml') | indent }}
  etcd.yaml: |
    {{ include_file('prometheus/rules/etcd.yaml') | indent }}
  ingress.yaml: |
    {{ include_file('prometheus/rules/ingress.yaml') | indent }}
...
```
Unfortunately, then somebody adds file to that folder, but forgets to update template.

To fix this I propose adding `list_files` function, so your template becomes:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: prometheus-rules
data:
  {% for f in list_files('prometheus/rules/*.yaml') %}
  {{ f.split('/')[-1] }}: |
    {{ include_file(f) | indent }}
  {% endfor %}
```
And you do not need to remember about updating template anymore.