### PR TITLE
Fix deploy for deprecated api versions

### DIFF
--- a/k8s_handle/__init__.py
+++ b/k8s_handle/__init__.py
@@ -11,7 +11,7 @@ from kubernetes.config import list_kube_config_contexts, load_kube_config
 from k8s_handle import config
 from k8s_handle import settings
 from k8s_handle import templating
-from k8s_handle.exceptions import DeprecationError, ProvisioningError, ResourceNotAvailableError
+from k8s_handle.exceptions import ProvisioningError, ResourceNotAvailableError
 from k8s_handle.filesystem import InvalidYamlError
 from k8s_handle.k8s.deprecation_checker import ApiDeprecationChecker
 from k8s_handle.k8s.provisioner import Provisioner
@@ -230,8 +230,6 @@ def main():
     except InvalidYamlError as e:
         log.error('{}'.format(e))
         sys.exit(1)
-    except DeprecationError as e:
-        log.warning('Deprecation warning: {}'.format(e))
     except RuntimeError as e:
         log.error('RuntimeError: {}'.format(e))
         sys.exit(1)

--- a/k8s_handle/exceptions.py
+++ b/k8s_handle/exceptions.py
@@ -2,10 +2,6 @@ class ProvisioningError(Exception):
     pass
 
 
-class DeprecationError(Exception):
-    pass
-
-
 class ResourceNotAvailableError(Exception):
     pass
 

--- a/k8s_handle/k8s/deprecation_checker.py
+++ b/k8s_handle/k8s/deprecation_checker.py
@@ -3,7 +3,6 @@ import logging
 import semver
 
 from k8s_handle.templating import get_template_contexts
-from k8s_handle.exceptions import DeprecationError
 
 log = logging.getLogger(__name__)
 
@@ -131,13 +130,7 @@ class ApiDeprecationChecker:
                     status="unsupported",
                     k8s_version=self.deprecated_versions[api_version][kind]["until"],
                 ))
-                raise DeprecationError(
-                    "Version {} for resourse type '{}' is unsupported since kubernetes {}".format(
-                        api_version,
-                        kind,
-                        self.deprecated_versions[api_version][kind]["until"]
-                    )
-                )
+                return True
 
         if self._is_server_version_greater(self.deprecated_versions[api_version][kind]["since"]):
             log.warning(message.format(

--- a/k8s_handle/k8s/test_deprecation_checker.py
+++ b/k8s_handle/k8s/test_deprecation_checker.py
@@ -1,6 +1,5 @@
 import unittest
 
-from k8s_handle.exceptions import DeprecationError
 from k8s_handle.k8s.deprecation_checker import ApiDeprecationChecker
 
 
@@ -76,8 +75,7 @@ class TestApiDeprecationChecker(unittest.TestCase):
                 },
             }
         }
-        with self.assertRaises(DeprecationError):
-            checker._is_deprecated("test/v1", "Deployment")
+        self.assertTrue(checker._is_deprecated("test/v1", "Deployment"))
 
     def test_version_is_unsupported(self):
         checker = ApiDeprecationChecker("1.10.6")
@@ -89,8 +87,7 @@ class TestApiDeprecationChecker(unittest.TestCase):
                 },
             }
         }
-        with self.assertRaises(DeprecationError):
-            checker._is_deprecated("test/v1", "Deployment")
+        self.assertTrue(checker._is_deprecated("test/v1", "Deployment"))
 
     def test_version_no_until(self):
         checker = ApiDeprecationChecker("1.10.6")


### PR DESCRIPTION
Deprecation checker currently silently blocks provisioning because of wrong placed `DeprecationError` exception handler:

https://github.com/2gis/k8s-handle/blob/678304c9d450b9923a6a9524d4420d2497c23914/k8s_handle/__init__.py#L233-L234

But it should be handled somewhere around: https://github.com/2gis/k8s-handle/blob/678304c9d450b9923a6a9524d4420d2497c23914/k8s_handle/__init__.py#L115-L116).

So, I suggest to remove exception completely.