### PR TITLE
Add support of autoscaling/v2beta2

### DIFF
--- a/k8s_handle/k8s/adapters.py
+++ b/k8s_handle/k8s/adapters.py
@@ -28,6 +28,7 @@ class Adapter:
         'storage.k8s.io/v1': client.StorageV1Api,
         'apps/v1': client.AppsV1Api,
         'autoscaling/v1': client.AutoscalingV1Api,
+        'autoscaling/v2beta2': client.AutoscalingV2beta2Api,
         'rbac.authorization.k8s.io/v1': client.RbacAuthorizationV1Api,
         'scheduling.k8s.io/v1alpha1': client.SchedulingV1alpha1Api,
         'scheduling.k8s.io/v1beta1': client.SchedulingV1beta1Api,
@@ -140,8 +141,8 @@ class AdapterBuiltinKind(Adapter):
             raise ProvisioningError(e)
         except ValueError as e:
             log.error(e)
-            # WORKAROUND https://github.com/kubernetes-client/gen/issues/52
-            if self.kind not in ['custom_resource_definition']:
+            # WORKAROUND https://github.com/kubernetes-client/gen/issues/52, https://github.com/kubernetes-client/python/issues/1098
+            if self.kind not in ['custom_resource_definition', 'horizontal_pod_autoscaler']:
                 raise e
 
     def replace(self, parameters):


### PR DESCRIPTION
Example output:
```
2020-06-02 07:21:55 INFO:k8s_handle.k8s.provisioner:HorizontalPodAutoscaler "seleznev-test-app" does not exist, create it
2020-06-02 07:21:55 ERROR:k8s_handle.k8s.adapters:Invalid value for `conditions`, must not be `None`
```