### PR TITLE
Use replace() for Services instead of patch()

### DIFF
--- a/k8s_handle/k8s/mocks.py
+++ b/k8s_handle/k8s/mocks.py
@@ -267,37 +267,6 @@ class K8sClientMock:
             raise ApiException('Replace persistent volume claim fail')
 
 
-class ServiceMetadata:
-    labels = {}
-
-    def __init__(self, annotations, labels):
-        if annotations is not None:
-            self.annotations = annotations
-        self.labels = labels
-
-
-class ServiceSpec:
-    def __init__(self, case):
-        if case in ['case1', 'case2', 'case3']:
-            self.ports = [ServicePort(55)]
-        if case in ['case4', 'case5', 'case7', 'case8']:
-            self.ports = [ServicePort(55, 'test')]
-        if case in ['case6']:
-            self.ports = [ServicePort(55, 'test', 90)]
-
-
-class ServicePort:
-    def __init__(self, port, name=None, target_port=None, node_port=None, protocol='TCP'):
-        self.port = port
-        self.name = name
-        self.node_port = node_port
-        self.protocol = protocol
-        if target_port is None:
-            self.target_port = port
-        else:
-            self.target_port = port
-
-
 class CustomObjectsAPIMock:
     pass
 

--- a/k8s_handle/k8s/test_adapters.py
+++ b/k8s_handle/k8s/test_adapters.py
@@ -114,10 +114,10 @@ class TestAdapterBuiltInKind(unittest.TestCase):
         self.assertEqual(res, {'key1': 'value1'})
 
     def test_app_replace_service(self):
-        deployment = AdapterBuiltinKind(
+        service = AdapterBuiltinKind(
             api=K8sClientMock(''),
-            spec={'kind': 'Service', 'metadata': {'name': ''}, 'spec': {'replicas': 1}})
-        res = deployment.replace({})
+            spec={'kind': 'Service', 'metadata': {'name': ''}, 'spec': {'type': 'ClusterIP'}})
+        res = service.replace({})
         self.assertEqual(res, {'key1': 'value1'})
 
     def test_app_delete_fail(self):

--- a/k8s_handle/k8s/test_provisioner.py
+++ b/k8s_handle/k8s/test_provisioner.py
@@ -5,9 +5,6 @@ from k8s_handle.exceptions import ProvisioningError
 from k8s_handle.templating import get_template_contexts
 from .adapters import AdapterBuiltinKind
 from .mocks import K8sClientMock
-from .mocks import ServiceMetadata
-from .mocks import ServicePort
-from .mocks import ServiceSpec
 from .provisioner import Provisioner
 
 
@@ -113,109 +110,6 @@ class TestProvisioner(unittest.TestCase):
             spec={'kind': 'Job', 'metadata': {'name': 'test1'}, 'spec': {'replicas': 1}})
         Provisioner('destroy', False, None)._wait_destruction_complete(client, 'Job', tries=1, timeout=0)
 
-    def test_missing_annotations_and_labels(self):
-        annotations = {
-            'annotation1': 'value1',
-            'annotation2': 'value2',
-            'annotation3': 'value3',
-            'kubectl.kubernetes.io/last-applied-configuration': {}
-        }
-
-        labels = {
-            'label1': 'value1',
-            'label2': 'value2',
-            'label3': 'value3'
-        }
-
-        old_metadata = ServiceMetadata(annotations, labels)
-        new_metadata = {
-            'annotations': {'annotation1': 'value1', 'annotation2': 'value2'},
-            'labels': {'label1': 'value1', 'label2': 'value2'}
-        }
-
-        missing_annotations, missing_labels = Provisioner('', False, None)._get_missing_annotations_and_labels(
-            old_metadata, new_metadata)
-
-        self.assertEqual(len(missing_annotations), 1)
-        self.assertEqual(missing_annotations[0], 'annotation3')
-        self.assertEqual(len(missing_labels), 1)
-        self.assertEqual(missing_labels[0], 'label3')
-
-    def test_no_missing_annotations_and_labels(self):
-        annotations = {'annotation1': 'value1'}
-
-        labels = {'label1': 'value1'}
-
-        old_metadata = ServiceMetadata(annotations, labels)
-        new_metadata = {
-            'annotations': {'annotation1': 'value1', 'annotation2': 'value2'},
-            'labels': {'label1': 'value1', 'label2': 'value2'}
-        }
-
-        missing_annotations, missing_labels = Provisioner('', False, None)._get_missing_annotations_and_labels(
-            old_metadata, new_metadata)
-
-        self.assertEqual(len(missing_annotations), 0)
-        self.assertEqual(len(missing_labels), 0)
-
-    def test_no_annotations_in_template(self):
-        annotations = {'annotation1': 'value1', 'annotation2': 'value2'}
-
-        labels = {'label1': 'value1'}
-
-        old_metadata = ServiceMetadata(annotations, labels)
-        new_metadata = {
-            'labels': {'label1': 'value1', 'label2': 'value2'}
-        }
-
-        missing_annotations, missing_labels = Provisioner('', False, None)._get_missing_annotations_and_labels(
-            old_metadata, new_metadata)
-
-        self.assertEqual(len(missing_annotations), 2)
-        self.assertEqual(len(missing_labels), 0)
-
-    def test_no_annotations_in_service_metadata(self):
-        labels = {'label1': 'value1'}
-
-        old_metadata = ServiceMetadata(None, labels)
-        new_metadata = {
-            'annotations': {'annotation1': 'value1'},
-            'labels': {'label1': 'value1', 'label2': 'value2'}
-        }
-
-        missing_annotations, missing_labels = Provisioner('', False, None)._get_missing_annotations_and_labels(
-            old_metadata, new_metadata)
-
-        self.assertEqual(len(missing_annotations), 0)
-        self.assertEqual(len(missing_labels), 0)
-
-    def test_missing_annotation_strict(self):
-        missing_annotations = ['a1', 'a2', 'a3']
-        settings.GET_ENVIRON_STRICT = True
-        with self.assertRaises(RuntimeError) as context:
-            Provisioner('', False, None)._notify_about_missing_items_in_template(items=missing_annotations,
-                                                                                 missing_type='annotation')
-        self.assertTrue('Please pay attention to service annotations!'
-                        in str(context.exception))
-
-    def test_missing_labels_strict(self):
-        missing_labels = ['a1', 'a2', 'a3']
-        settings.GET_ENVIRON_STRICT = True
-        with self.assertRaises(RuntimeError) as context:
-            Provisioner('', False, None)._notify_about_missing_items_in_template(items=missing_labels,
-                                                                                 missing_type='label')
-        self.assertTrue('Please pay attention to service labels!'
-                        in str(context.exception))
-
-    def test_missing_ports_strict(self):
-        missing_ports = [ServicePort(80, 'test1'), ServicePort(90, 'test2'), ServicePort(50, None)]
-        settings.GET_ENVIRON_STRICT = True
-        with self.assertRaises(RuntimeError) as context:
-            Provisioner('', False, None)._notify_about_missing_items_in_template(items=missing_ports,
-                                                                                 missing_type='port')
-        self.assertTrue('Please pay attention to service ports!'
-                        in str(context.exception))
-
     def test_deploy_replace(self):
         settings.CHECK_STATUS_TIMEOUT = 0
         Provisioner('deploy', False, None).run("k8s_handle/k8s/fixtures/deployment.yaml")
@@ -251,78 +145,6 @@ class TestProvisioner(unittest.TestCase):
 
     def test_destroy_success(self):
         Provisioner('destroy', False, None).run("k8s_handle/k8s/fixtures/deployment.yaml")
-
-    def test_get_apply_ports_case1(self):
-        # old_port=55, new_port=55, res: no apply ports
-        old_spec = ServiceSpec('case1')
-        new_spec = {'ports': [{'port': 55}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 0)
-
-    def test_get_apply_ports_case2(self):
-        # old_port=55, new_port=56, res: 1 apply port, 1 deleted
-        old_spec = ServiceSpec('case2')
-        new_spec = {'ports': [{'port': 56}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 2)
-        self.assertDictEqual(apply_ports[0], {'port': 55, '$patch': 'delete'})
-        self.assertDictEqual(apply_ports[1], {'port': 56})
-
-    def test_get_apply_ports_case3(self):
-        # old_port=55, new_port=56, name=test, res: 1 apply port, 1 deleted
-        old_spec = ServiceSpec('case3')
-        new_spec = {'ports': [{'port': 56, 'name': 'test'}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 2)
-        self.assertDictEqual(apply_ports[0], {'port': 55, '$patch': 'delete'})
-        self.assertDictEqual(apply_ports[1], {'port': 56, 'name': 'test'})
-
-    def test_get_apply_ports_case4(self):
-        # old_port=55,name=test, new_port=56,name=test, res: 1 apply port, 1 deleted
-        old_spec = ServiceSpec('case4')
-        new_spec = {'ports': [{'port': 56, 'name': 'foo'}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 2)
-        self.assertDictEqual(apply_ports[0], {'port': 55, '$patch': 'delete'})
-        self.assertDictEqual(apply_ports[1], {'port': 56, 'name': 'foo'})
-
-    def test_get_apply_ports_case5(self):
-        # add targetPort to existent port, res: 1 apply port
-        old_spec = ServiceSpec('case5')
-        new_spec = {'ports': [{'port': 55, 'name': 'test', 'targetPort': 90}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 1)
-        self.assertDictEqual(apply_ports[0], {'port': 55, 'node_port': None,
-                                              'protocol': 'TCP', 'name': 'test', 'targetPort': 90})
-
-    def test_get_apply_ports_case6(self):
-        # change targetPort, res: 1 apply port
-        old_spec = ServiceSpec('case6')
-        new_spec = {'ports': [{'port': 55, 'name': 'test', 'targetPort': 99}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 1)
-        self.assertDictEqual(apply_ports[0], {'port': 55, 'node_port': None,
-                                              'protocol': 'TCP', 'name': 'test', 'targetPort': 99})
-
-    def test_get_apply_ports_case7(self):
-        # change protocol, res: 1 apply port
-        old_spec = ServiceSpec('case7')
-        new_spec = {'ports': [{'port': 55, 'name': 'test', 'protocol': 'UDP'}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 1)
-        self.assertDictEqual(apply_ports[0], {'port': 55, 'node_port': None,
-                                              'protocol': 'UDP', 'name': 'test', 'target_port': 55})
-
-    def test_get_apply_ports_case8(self):
-        # add new ports, res: 1 delete, 2 apply
-        old_spec = ServiceSpec('case8')
-        new_spec = {'ports': [{'port': 90, 'name': 'test1'},
-                              {'port': 99, 'name': 'test2'}]}
-        apply_ports = Provisioner('deploy', False, None)._get_apply_ports(old_spec, new_spec)
-        self.assertEqual(len(apply_ports), 3)
-        self.assertDictEqual(apply_ports[0], {'port': 55, '$patch': 'delete'})
-        self.assertDictEqual(apply_ports[1], {'port': 90, 'name': 'test1'})
-        self.assertDictEqual(apply_ports[2], {'port': 99, 'name': 'test2'})
 
     def test_pvc_replace_equals(self):
         Provisioner('deploy', False, None).run("k8s_handle/k8s/fixtures/pvc.yaml")


### PR DESCRIPTION
k8s-handle uses `patch()` API call for Services because of historical reason (looks like kubectl didn't support replace for services some years ago) and can't delete labels/annotations from the Services:

```
2020-10-13 06:25:37 INFO:k8s_handle.k8s.provisioner:Service "test-service" already exists, replace it
2020-10-13 06:25:37 WARNING:k8s_handle.k8s.provisioner:
       ___
    .-'   `-.
   /  \   /  \\     Please pay attention to service annotations!
  .   o\ /o   .    The next annotation(s) missing in template:
  |___  ^  ___|    "test-annotation"
      |___|        They won\'t be deleted after service apply.
      |||||
```

I propose to start using `replace()` for Services because kubernetes client works well for now.