### PR TITLE
Fix custom resources deletion and update dependencies

### DIFF
--- a/k8s_handle/k8s/adapters.py
+++ b/k8s_handle/k8s/adapters.py
@@ -278,12 +278,12 @@ class AdapterCustomKind(Adapter):
             if self.namespace:
                 return self.api.delete_namespaced_custom_object(
                     self.group, self.version, self.namespace, self.plural, self.name,
-                    client.V1DeleteOptions(propagation_policy='Foreground')
+                    body=client.V1DeleteOptions(propagation_policy='Foreground')
                 )
 
             return self.api.delete_cluster_custom_object(
                 self.group, self.version, self.plural, self.name,
-                client.V1DeleteOptions(propagation_policy='Foreground')
+                body=client.V1DeleteOptions(propagation_policy='Foreground')
             )
 
         except ApiException as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests==2.22.0
-jinja2==2.10.1
-PyYAML==5.1
-kubernetes==12.0.0
-semver==2.8.1
+requests==2.25.0
+jinja2==2.11.2
+PyYAML==5.3.1
+kubernetes==12.0.1
+semver==2.13.0


### PR DESCRIPTION
After upgrade k8s client to 12.0.0 in #132 deletion custom objects doesn't work anymore:

```
2020-12-11 02:22:14 INFO:k8s_handle.k8s.provisioner:Trying to delete VerticalPodAutoscaler "seleznev-test-app"
Traceback (most recent call last):
  File "/usr/local/bin/k8s-handle", line 33, in <module>
    sys.exit(load_entry_point('k8s-handle==0.0.0', 'console_scripts', 'k8s-handle')())
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/__init__.py", line 226, in main
    args.func(args_dict)
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/__init__.py", line 32, in handler_destroy
    _handler_deploy_destroy(args, COMMAND_DESTROY)
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/__init__.py", line 69, in _handler_deploy_destroy
    args.get('show_logs')
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/__init__.py", line 121, in _handler_provision
    provisioner.run(resource)
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/k8s/provisioner.py", line 43, in run
    self._destroy_all(file_path)
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/k8s/provisioner.py", line 169, in _destroy_all
    self._destroy(template_body, file_path)
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/k8s/provisioner.py", line 184, in _destroy
    response = kube_client.delete()
  File "/usr/local/lib/python3.6/site-packages/k8s_handle-0.0.0-py3.6.egg/k8s_handle/k8s/adapters.py", line 281, in delete
    client.V1DeleteOptions(propagation_policy='Foreground')
TypeError: delete_namespaced_custom_object() takes 6 positional arguments but 7 were given
```

Change in client which caused this issue:

> [v11.0.0](https://github.com/kubernetes-client/python/blob/release-11.0/CHANGELOG.md)
>
> API Change:
> 
> * Deleting CustomObjects doesn't require passing in the body anymore kubernetes-client/gen#142

---

Also I updated dependencies because of:

```
error: urllib3 1.26.2 is installed but urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 is required by {'requests'}
```