### PR TITLE
Use replace() API call for Custom Resources

### DIFF
--- a/k8s_handle/k8s/adapters.py
+++ b/k8s_handle/k8s/adapters.py
@@ -294,16 +294,19 @@ class AdapterCustomKind(Adapter):
                 '{}'.format(add_indent(e.body)))
             raise ProvisioningError(e)
 
-    def replace(self, _):
+    def replace(self, parameters):
         self._validate()
+
+        if 'resourceVersion' in parameters:
+            self.body['metadata']['resourceVersion'] = parameters['resourceVersion']
 
         try:
             if self.namespace:
-                return self.api.patch_namespaced_custom_object(
+                return self.api.replace_namespaced_custom_object(
                     self.group, self.version, self.namespace, self.plural, self.name, self.body
                 )
 
-            return self.api.patch_cluster_custom_object(
+            return self.api.replace_cluster_custom_object(
                 self.group, self.version, self.plural, self.name, self.body
             )
         except ApiException as e:

--- a/k8s_handle/k8s/provisioner.py
+++ b/k8s_handle/k8s/provisioner.py
@@ -94,6 +94,13 @@ class Provisioner:
             log.info('{} "{}" already exists, replace it'.format(template_body['kind'], kube_client.name))
             parameters = {}
 
+            if hasattr(resource, 'metadata'):
+                if hasattr(resource.metadata, 'resource_version'):
+                    parameters['resourceVersion'] = resource.metadata.resource_version
+            elif 'metadata' in resource:
+                if 'resourceVersion' in resource['metadata']:
+                    parameters['resourceVersion'] = resource['metadata']['resourceVersion']
+
             if template_body['kind'] == 'Service':
                 if hasattr(resource.spec, 'cluster_ip'):
                     parameters['clusterIP'] = resource.spec.cluster_ip
@@ -107,10 +114,6 @@ class Provisioner:
                 if resource.status.phase in ['Bound', 'Released']:
                     log.warning('PersistentVolume has "{}" status, skip replacing'.format(resource.status.phase))
                     return
-
-            if template_body['kind'] in ['Service', 'CustomResourceDefinition', 'PodDisruptionBudget']:
-                if hasattr(resource.metadata, 'resource_version'):
-                    parameters['resourceVersion'] = resource.metadata.resource_version
 
             kube_client.replace(parameters)
 


### PR DESCRIPTION
Motivation:

* `patch()` API call doesn't work well when you delete something (annotations, for ex.) from templates (deleted parts still presents in the cluster after `patch()`).
* For most another resource types we use `replace()` already.