### PR TITLE
Add support for autoscaling/v2 API

### DIFF
--- a/k8s_handle/k8s/adapters.py
+++ b/k8s_handle/k8s/adapters.py
@@ -27,6 +27,7 @@ class Adapter:
         'storage.k8s.io/v1': client.StorageV1Api,
         'apps/v1': client.AppsV1Api,
         'autoscaling/v1': client.AutoscalingV1Api,
+        'autoscaling/v2': client.AutoscalingV2Api,
         'autoscaling/v2beta2': client.AutoscalingV2beta2Api,
         'rbac.authorization.k8s.io/v1': client.RbacAuthorizationV1Api,
         'scheduling.k8s.io/v1': client.SchedulingV1Api,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jinja2==3.1.2
 PyYAML==5.4.1
 kubernetes==24.2.0
 semver==2.13.0
+urllib3==1.26.13


### PR DESCRIPTION
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126:

> The autoscaling/v2beta2 API version of HorizontalPodAutoscaler is no longer served as of v1.26.
> * Migrate manifests and API clients to use the autoscaling/v2 API version, available since v1.23.

---

Also I added urllib3 into requirements.txt because:

* We use it in tests directly.
* `docker build` broken because of 2.0.0a2 release:
  ```
  error: urllib3 2.0.0a2 is installed but urllib3<1.27,>=1.21.1 is required by {'requests'}
  ```
