### PR TITLE
Update ignored fields (for diff command) and filter them out from new manifests as well

### DIFF
--- a/k8s_handle/k8s/diff.py
+++ b/k8s_handle/k8s/diff.py
@@ -14,12 +14,14 @@ IGNORE_FIELDS = [
     'metadata.annotations:kubectl.kubernetes.io/last-applied-configuration',
     'metadata.annotations:deployment.kubernetes.io/revision',
     'metadata:creationTimestamp',
+    'metadata.labels:kubernetes.io/metadata.name',
     'metadata:resourceVersion',
     'metadata:selfLink',
     'metadata:uid',
     'metadata:namespace',
     'metadata:generation',
     'metadata:managedFields',
+    'spec:finalizers',
     'status'
 ]
 

--- a/k8s_handle/k8s/diff.py
+++ b/k8s_handle/k8s/diff.py
@@ -67,21 +67,22 @@ class Diff:
                 log.info(f'Skipping secret {template_body.get("metadata", {}).get("name")}')
                 continue
             kube_client = Adapter.get_instance(template_body)
-            new = yaml.safe_dump(template_body)
             k8s_object = kube_client.get()
             if k8s_object is None:
                 current_dict = {}
             else:
                 current_dict = to_dict(k8s_object)
-            for field_path in IGNORE_FIELDS:
-                try:
-                    apply_filter(current_dict, field_path)
-                except KeyError:
-                    pass
+            for d in (template_body, current_dict):
+                for field_path in IGNORE_FIELDS:
+                    try:
+                        apply_filter(d, field_path)
+                    except KeyError:
+                        pass
             metadata = current_dict.get('metadata', {})
             if 'annotations' in metadata and metadata['annotations'] == {}:
                 del metadata['annotations']
             current = yaml.safe_dump(current_dict)
+            new = yaml.safe_dump(template_body)
             if new == current:
                 log.info(f' Kind: "{template_body.get("kind")}", '
                          f'name: "{template_body.get("metadata", {}).get("name")}" : NO CHANGES')


### PR DESCRIPTION
Current implementation has some issues: 

1. The apiserver automatically adds `kubernetes.io/metadata.name` label and `spec.finalizers: ["kubernetes"]`. There is no need to show these in the diff. 
2. Users may have some of the ignored fields in their templates (for example, `metadata.namespace`).